### PR TITLE
Add support for enumerated values to field definitions.

### DIFF
--- a/generate-tests.sh
+++ b/generate-tests.sh
@@ -19,6 +19,7 @@ main() {
         Toshiba/M368
         Toshiba/M369
         Toshiba/M36B
+        SiliconLabs/SIM3L1x8_SVD
     )
 
     rm -rf tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl Register {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Access {
     ReadOnly,
     ReadWrite,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,25 +305,9 @@ impl EnumeratedValues {
 }
 
 #[derive(Debug)]
-pub struct Choice {
-    value: Option<u32>,
-    is_default: Option<bool>,
-}
-
-impl Choice {
-    fn parse(tree: &Element) -> Choice {
-        Choice {
-            value: try!(tree.get_child_text("value")).parse().ok(),
-            is_default: try!(tree.get_child_text("isDefault")).parse().ok(),
-        }
-    }
-}
-
-#[derive(Debug)]
 pub struct EnumeratedValue {
     pub name: String,
     pub description: Option<String>,
-    pub choice: Option<Choice>,
     pub value: u32,
 }
 
@@ -336,7 +320,6 @@ impl EnumeratedValue {
         Some(EnumeratedValue {
             name: try!(tree.get_child_text("name")),
             description: tree.get_child_text("description"),
-            choice: tree.get_child("choice").map(Choice::parse),
             value: try!(parse::u32(try!(tree.get_child("value")))),
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,7 @@ pub struct Field {
     pub name: String,
     pub description: Option<String>,
     pub bit_range: BitRange,
+    pub access: Option<Access>,
     pub enumerated_values: Option<EnumeratedValues>,
 }
 
@@ -201,6 +202,7 @@ impl Field {
             name: try!(tree.get_child_text("name")),
             description: tree.get_child_text("description"),
             bit_range: BitRange::parse(tree),
+            access: tree.get_child("access").map(Access::parse),
 
             enumerated_values:
                 tree.get_child("enumeratedValues").map(EnumeratedValues::parse),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,8 @@ impl EnumeratedValues {
 pub struct EnumeratedValue {
     pub name: String,
     pub description: Option<String>,
-    pub value: u32,
+    pub value: Option<u32>,
+    pub is_default: Option<bool>,
 }
 
 impl EnumeratedValue {
@@ -322,7 +323,8 @@ impl EnumeratedValue {
         Some(EnumeratedValue {
             name: try!(tree.get_child_text("name")),
             description: tree.get_child_text("description"),
-            value: try!(parse::u32(try!(tree.get_child("value")))),
+            value: tree.get_child("value").map(|t| try!(parse::u32(t))),
+            is_default: tree.get_child_text("isDefault").map(|t| try!(t.parse())),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ pub struct BitRange {
 
 impl BitRange {
     fn parse(tree: &Element) -> BitRange {
-        let (start, end) = if let Some(range) = tree.get_child("bitRange") {
+        let (end, start): (u32, u32) = if let Some(range) = tree.get_child("bitRange") {
             let text = try!(range.text.as_ref());
 
             assert!(text.starts_with('['));
@@ -229,7 +229,7 @@ impl BitRange {
             (try!(try!(parts.next()).parse()), try!(try!(parts.next()).parse()))
         } else if let (Some(lsb), Some(msb)) = (tree.get_child_text("lsb"),
                                                                    tree.get_child_text("msb")) {
-            (try!(lsb.parse()), try!(msb.parse::<u32>()))
+            (try!(msb.parse()), try!(lsb.parse::<u32>()))
         } else {
             return BitRange {
                 offset: try!(try!(tree.get_child_text("bitOffset")).parse()),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,6 +5,11 @@ pub fn u32(tree: &Element) -> Option<u32> {
 
     if text.starts_with("0x") || text.starts_with("0X") {
         u32::from_str_radix(&text["0x".len()..], 16).ok()
+    } else if text.starts_with("#") {
+        // Handle strings in the binary form of:
+        // #01101x1
+        // along with don't care character x (replaced with 0)
+        u32::from_str_radix(&str::replace(&text["#".len()..], "x", "0"), 2).ok()
     } else {
         text.parse().ok()
     }


### PR DESCRIPTION
Freescale and Atmel both utilize these fields. Let me know if the implementation is sound. Note the Freescale stuff is encoding its values with #0101x01 which we support. Discussion of that is here:
https://github.com/posborne/cmsis-svd/issues/14