### PR TITLE
Add access field to defaults

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,7 @@ pub struct Defaults {
     pub size: Option<u32>,
     pub reset_value: Option<u32>,
     pub reset_mask: Option<u32>,
+    pub access: Option<Access>,
 }
 
 impl Defaults {
@@ -272,6 +273,7 @@ impl Defaults {
             size: tree.get_child("size").map(|t| try!(parse::u32(t))),
             reset_value: tree.get_child("resetValue").map(|t| try!(parse::u32(t))),
             reset_mask: tree.get_child("resetMask").map(|t| try!(parse::u32(t))),
+            access: tree.get_child("access").map(Access::parse),
         }
     }
 }


### PR DESCRIPTION
Access field can be present in device node,
and it's value should be inherited down the line.
Examples:
- lm3s6965.svd (access field is present and is used)
- ARMCM3.svd (access field is present, but is not used)

Side note:
Maybe this whole inheritance (and derivedFrom) thing can be done in parser?
So you don't have to deal with all this Options later on.
Or is it better to keep parser plain and simple?