### PR TITLE
Basic support for register arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["CMSIS", "SVD", "parser"]
 license = "MIT OR Apache-2.0"
 name = "svd-parser"
 repository = "https://github.com/japaric/svd"
-version = "0.1.2"
+version = "0.1.3"
 
 [dependencies]
 xmltree = "0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@
 
 extern crate xmltree;
 
+use std::ops::Deref;
+
 use xmltree::Element;
 
 macro_rules! try {
@@ -141,7 +143,7 @@ impl Interrupt {
 }
 
 #[derive(Clone, Debug)]
-pub struct Register {
+pub struct RegisterInfo {
     pub name: String,
     pub description: String,
     pub address_offset: u32,
@@ -150,6 +152,56 @@ pub struct Register {
     pub reset_value: Option<u32>,
     pub reset_mask: Option<u32>,
     pub fields: Option<Vec<Field>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RegisterArrayInfo {
+    pub dim: u32,
+    pub dim_increment: u32,
+    pub dim_index: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Register {
+    Single(RegisterInfo),
+    Array(RegisterInfo, RegisterArrayInfo),
+}
+
+impl Deref for Register {
+    type Target = RegisterInfo;
+
+    fn deref(&self) -> &RegisterInfo {
+        match *self {
+            Register::Single(ref info) => info,
+            Register::Array(ref info, _) => info
+        }
+    }
+}
+
+impl RegisterInfo {
+    fn parse(tree: &Element) -> RegisterInfo {
+        RegisterInfo {
+            name: try!(tree.get_child_text("name")),
+            description: try!(tree.get_child_text("description")),
+            address_offset: try!(parse::u32(try!(tree.get_child("addressOffset")))),
+            size: tree.get_child("size").map(|t| try!(parse::u32(t))),
+            access: tree.get_child("access").map(Access::parse),
+            reset_value: tree.get_child("resetValue").map(|t| try!(parse::u32(t))),
+            reset_mask: tree.get_child("resetMask").map(|t| try!(parse::u32(t))),
+            fields: tree.get_child("fields")
+                .map(|fs| fs.children.iter().map(Field::parse).collect()),
+        }
+    }
+}
+
+impl RegisterArrayInfo {
+    fn parse(tree: &Element) -> RegisterArrayInfo {
+        RegisterArrayInfo {
+            dim: try!(tree.get_child_text("dim").unwrap().parse::<u32>()),
+            dim_increment: try!(tree.get_child("dimIncrement").map(|t| try!(parse::u32(t)))),
+            dim_index: None
+        }
+    }
 }
 
 impl Register {
@@ -161,17 +213,15 @@ impl Register {
 
         assert_eq!(tree.name, "register");
 
-        Some(Register {
-            name: try!(tree.get_child_text("name")),
-            description: try!(tree.get_child_text("description")),
-            address_offset: try!(parse::u32(try!(tree.get_child("addressOffset")))),
-            size: tree.get_child("size").map(|t| try!(parse::u32(t))),
-            access: tree.get_child("access").map(Access::parse),
-            reset_value: tree.get_child("resetValue").map(|t| try!(parse::u32(t))),
-            reset_mask: tree.get_child("resetMask").map(|t| try!(parse::u32(t))),
-            fields: tree.get_child("fields")
-                .map(|fs| fs.children.iter().map(Field::parse).collect()),
-        })
+        let info = RegisterInfo::parse(tree);
+
+        match tree.get_child("dimIncrement") {
+            Some(_) => {
+                let array_info = RegisterArrayInfo::parse(tree);
+                Some(Register::Array(info, array_info))
+            },
+            None => Some(Register::Single(info))
+        }
     }
 }
 


### PR DESCRIPTION
Not really sure about the design here, probably it would be better to have a distinct `RegisterArray` type
or something so that the users (e.g. svd2rust) can decide how to handle those themselves. But this 
is a starting point at least.

Another thing to discuss/improve here is the representation of register arrays. Currently it's all exploded, which is not nice. If we're going to create proper arrays on the Rust side, we need to see what to do
with non-integer indices (i.e. the dimIndex case).