### PR TITLE
Added support for parsing writeConstraint which is supported SVD field.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["CMSIS", "SVD", "parser"]
 license = "MIT OR Apache-2.0"
 name = "svd-parser"
 repository = "https://github.com/japaric/svd"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 xmltree = "0.3.2"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,6 +15,11 @@ pub fn u32(tree: &Element) -> Option<u32> {
     }
 }
 
+pub fn bool(tree: &Element) -> Option<bool> {
+    let text = try!(tree.text.as_ref());
+    text.parse::<bool>().ok()
+}
+
 pub fn dim_index(text: &str) -> Vec<String> {
     if text.contains('-') {
         let mut parts = text.splitn(2, '-');


### PR DESCRIPTION
writeConstraint is a child of the "field" element and can have a: writeAsRead,
useEnumeratedValues, or range element. These elements are all mutually exclusive.
As a result writeConstraint was implemented as an enum.

For details please see: https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_registers.html#elem_writeConstraint

I tested this by adding:

```xml
              <writeConstraint>
                <range>
                  <minimum>0</minimum>
                  <maximum>4294967295</maximum>
                </range>
              </writeConstraint>
```
```xml
              <writeConstraint>
                <useEnumeratedValues>true</useEnumeratedValues>
              </writeConstraint>
```

and 

```xml
              <writeConstraint>
                <writeAsRead>true</writeAsRead>
              </writeConstraint>
```
To 3 different fields in an svd file, and all of these appear to work well.

Fixes #24