### PR TITLE
Fixed underflow when width is 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,7 @@ impl BitRange {
 
         BitRange {
             offset: start,
-            width: end - start + 1,
+            width: end + 1 - start,
         }
     }
 }


### PR DESCRIPTION
I'm not sure why the width is set as 0, but this prevents a panic

cc @whitequark 