### PR TITLE
allow 0 and 1 as boolean values as per SVD spec

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -17,7 +17,11 @@ pub fn u32(tree: &Element) -> Option<u32> {
 
 pub fn bool(tree: &Element) -> Option<bool> {
     let text = try!(tree.text.as_ref());
-    text.parse::<bool>().ok()
+    match text.as_ref() {
+        "0" => Some(false),
+        "1" => Some(true),
+        _ => text.parse::<bool>().ok()
+    }
 }
 
 pub fn dim_index(text: &str) -> Vec<String> {


### PR DESCRIPTION
according to the [XML Schema](https://www.w3.org/TR/xmlschema-2/#boolean) specification regarding `xs:boolean`:

> 3.2.2.1 Lexical representation
>
> An instance of a datatype that is defined as ·boolean· can have the following legal literals **{true, false, 1, 0}**.

The SVD spec, likewise, seems to mention [a few times](http://www.keil.com/pack/doc/CMSIS/SVD/html/elem_cpu.html):

> This tag is either set to **true or false, 1 or 0**.

This pull request allows parsing 0 and 1 as false and true, respectively.