### PR TITLE
Added parsing of binary numbers with '0b' as a prefix

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,6 +10,11 @@ pub fn u32(tree: &Element) -> Option<u32> {
         // #01101x1
         // along with don't care character x (replaced with 0)
         u32::from_str_radix(&str::replace(&text["#".len()..], "x", "0"), 2).ok()
+    } else if text.starts_with("0b"){
+        // Handle strings in the binary form of:
+        // 0b01101x1
+        // along with don't care character x (replaced with 0)
+        u32::from_str_radix(&str::replace(&text["0b".len()..], "x", "0"), 2).ok()
     } else {
         text.parse().ok()
     }


### PR DESCRIPTION
I have an SVD file that is attached in japaric/svd2rust#146 that was failing parsing. I tracked it down to enumeratedValues having value tags with text in the format of '0b#' where '#' is a 0 or 1. I added an else clause to check for that and convert appropriately and keep the same 'don't care' syntax as the existing binary parsing.

There is still another issue with the SVD file, but it does not panic at least now at that stage.