### PR TITLE
Add a function to produce merged peripheral when derivedFrom is used.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,23 @@ pub struct Peripheral {
 }
 
 impl Peripheral {
+    pub fn derive_from(&self, other: &Peripheral) -> Peripheral {
+        let mut derived = self.clone();
+        if derived.group_name.is_none() && other.group_name.is_some() {
+            derived.group_name = other.group_name.clone();
+        }
+        if derived.description.is_none() && other.description.is_some() {
+            derived.description = other.description.clone();
+        }
+        if derived.registers.is_none() && other.registers.is_some() {
+            derived.registers = other.registers.clone();
+        }
+        if derived.interrupt.is_empty() {
+            derived.interrupt = other.interrupt.clone();
+        }
+        derived
+    }
+
     fn parse(tree: &Element) -> Peripheral {
         assert_eq!(tree.name, "peripheral");
 


### PR DESCRIPTION
Added a function to make a new peripheral by overlaying the peripheral over its derivedFrom peripheral. I read the spec that it is a shallow copy, but I could be wrong. This may be part of #21.

With this change, and another one that I have for svd2rust, svd2rust can generate peripherals with derivedFrom. I could have put this function over there, but I think the way overlaying is done is a part of the SVD spec, and not part of the particular svd2rust implementation, so it makes more sense for me to put it here.