### PR TITLE
Parse <register><alternateRegister> elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.rs.bk
+[._]*.sw[a-p]
 Cargo.lock
 target
 tests/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,9 @@ pub struct ClusterInfo {
 #[derive(Clone, Debug)]
 pub struct RegisterInfo {
     pub name: String,
+    pub alternate_group: Option<String>,
     pub alternate_register: Option<String>,
+    pub derived_from: Option<String>,
     pub description: String,
     pub address_offset: u32,
     pub size: Option<u32>,
@@ -352,7 +354,9 @@ impl RegisterInfo {
     fn parse(tree: &Element) -> RegisterInfo {
         RegisterInfo {
             name: try!(tree.get_child_text("name")),
+            alternate_group: tree.get_child_text("alternateGroup"),
             alternate_register: tree.get_child_text("alternateRegister"),
+            derived_from: tree.attributes.get("derivedFrom").map(|s| s.to_owned()),
             description: try!(tree.get_child_text("description")),
             address_offset: {
                 try!(parse::u32(try!(tree.get_child("addressOffset"))))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,7 @@ pub struct ClusterInfo {
 #[derive(Clone, Debug)]
 pub struct RegisterInfo {
     pub name: String,
+    pub alternate_register: Option<String>,
     pub description: String,
     pub address_offset: u32,
     pub size: Option<u32>,
@@ -351,6 +352,7 @@ impl RegisterInfo {
     fn parse(tree: &Element) -> RegisterInfo {
         RegisterInfo {
             name: try!(tree.get_child_text("name")),
+            alternate_register: tree.get_child_text("alternateRegister"),
             description: try!(tree.get_child_text("description")),
             address_offset: {
                 try!(parse::u32(try!(tree.get_child("addressOffset"))))


### PR DESCRIPTION
In looking at https://github.com/japaric/svd2rust/issues/191 and https://github.com/japaric/svd2rust/issues/16 I thought that this might help, so here's the trivial patch.