### PR TITLE
Made the u32 parse use the Parse trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl ElementExt for Element {
     /// Get a u32 value from a named child element
     fn get_child_u32(&self, n: &str) -> Result<u32, SVDError> {
         let s = self.get_child_elem(n)?;
-        parse::u32(&s).context(SVDErrorKind::ParseError(self.clone())).map_err(|e| e.into())
+        u32::parse(&s).context(SVDErrorKind::ParseError(self.clone())).map_err(|e| e.into())
     }
 
     /// Get a bool value from a named child element

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,35 +1,10 @@
 use xmltree::Element;
-use failure::ResultExt;
-use ElementExt;
 
 use error::*;
 
 macro_rules! try {
     ($e:expr) => {
         $e.expect(concat!(file!(), ":", line!(), " ", stringify!($e)))
-    }
-}
-
-// TODO: Should work on &str not Element
-// TODO: `parse::u32` should not hide it's errors, see `BitRange::parse`
-pub fn u32(tree: &Element) -> Result<u32, SVDError> {
-    let text = tree.get_text()?;
-
-    if text.starts_with("0x") || text.starts_with("0X") {
-        u32::from_str_radix(&text["0x".len()..], 16).context(SVDErrorKind::Other(format!("{} invalid", text))).map_err(|e| e.into())
-    } else if text.starts_with('#') {
-        // Handle strings in the binary form of:
-        // #01101x1
-        // along with don't care character x (replaced with 0)
-        u32::from_str_radix(&str::replace(&text.to_lowercase()["#".len()..], "x", "0"), 2).context(SVDErrorKind::Other(format!("{} invalid", text))).map_err(|e| e.into())
-    } else if text.starts_with("0b"){
-        // Handle strings in the binary form of:
-        // 0b01101x1
-        // along with don't care character x (replaced with 0)
-        u32::from_str_radix(&str::replace(&text["0b".len()..], "x", "0"), 2).context(SVDErrorKind::Other(format!("{} invalid", text))).map_err(|e| e.into())
-
-    } else {
-        text.parse::<u32>().context(SVDErrorKind::Other(format!("{} invalid", text))).map_err(|e| e.into())
     }
 }
 

--- a/src/svd/bitrange.rs
+++ b/src/svd/bitrange.rs
@@ -2,7 +2,6 @@
 use xmltree::Element;
 use failure::ResultExt;
 
-use parse;
 use types::{Parse, new_element};
 use error::*;
 
@@ -48,9 +47,9 @@ impl Parse for BitRange {
         // TODO: Consider matching instead so we can say which of these tags are missing
         } else if let (Some(lsb), Some(msb)) = (tree.get_child("lsb"), tree.get_child("msb")) {
             (
-                // TODO: `parse::u32` should not hide it's errors
-                parse::u32(msb).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::MsbLsb))?, 
-                parse::u32(lsb).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::MsbLsb))?, 
+                // TODO: `u32::parse` should not hide it's errors
+                u32::parse(msb).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::MsbLsb))?, 
+                u32::parse(lsb).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::MsbLsb))?, 
                 BitRangeType::MsbLsb
             )
         } else if let (Some(offset), Some(width)) = (tree.get_child("bitOffset"), tree.get_child("bitWidth")) {
@@ -59,9 +58,9 @@ impl Parse for BitRange {
                 // (ie. do not need to be calculated as in the final step)
                 return Ok(BitRange {
                     // TODO: capture that error comes from offset/width tag
-                    // TODO: `parse::u32` should not hide it's errors
-                    offset: parse::u32(offset).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::ParseError))?, 
-                    width: parse::u32(width).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::ParseError))?, 
+                    // TODO: `u32::parse` should not hide it's errors
+                    offset: u32::parse(offset).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::ParseError))?, 
+                    width: u32::parse(width).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::ParseError))?, 
                     range_type: BitRangeType::OffsetWidth
                 })
             )

--- a/src/svd/clusterinfo.rs
+++ b/src/svd/clusterinfo.rs
@@ -37,13 +37,13 @@ impl Parse for ClusterInfo {
             header_struct_name: tree.get_child_text_opt("headerStructName")?,
             address_offset: 
                 tree.get_child_u32("addressOffset")?,
-            size: parse::optional("size", tree, parse::u32)?,
+            size: parse::optional("size", tree, u32::parse)?,
             //access: tree.get_child("access").map(|t| Access::parse(t).ok() ),
             access: parse::optional("access", tree, Access::parse)?,
             reset_value:
-                parse::optional("resetValue", tree, parse::u32)?,
+                parse::optional("resetValue", tree, u32::parse)?,
             reset_mask:
-                parse::optional("resetMask", tree, parse::u32)?,
+                parse::optional("resetMask", tree, u32::parse)?,
             children: {
                 let children: Result<Vec<_>,_> = tree.children
                     .iter()

--- a/src/svd/defaults.rs
+++ b/src/svd/defaults.rs
@@ -23,9 +23,9 @@ impl Parse for Defaults {
 
     fn parse(tree: &Element) -> Result<Defaults, SVDError> {
         Ok(Defaults {
-            size: parse::optional("size", tree, parse::u32)?,
-            reset_value: parse::optional("resetValue", tree, parse::u32)?,
-            reset_mask: parse::optional("resetMask", tree, parse::u32)?,
+            size: parse::optional("size", tree, u32::parse)?,
+            reset_value: parse::optional("resetValue", tree, u32::parse)?,
+            reset_mask: parse::optional("resetMask", tree, u32::parse)?,
             access: parse::optional("access", tree, Access::parse).unwrap(),
             _extensible: (),
         })

--- a/src/svd/device.rs
+++ b/src/svd/device.rs
@@ -37,7 +37,7 @@ impl Parse for Device {
             cpu: parse::optional("cpu", tree, Cpu::parse)?,
             version: tree.get_child_text_opt("version")?,
             description: tree.get_child_text_opt("description")?,
-            address_unit_bits: parse::optional("addressUnitBits", tree, parse::u32)?,
+            address_unit_bits: parse::optional("addressUnitBits", tree, u32::parse)?,
             width: None,
             peripherals: {
                 let ps: Result<Vec<_>, _> = tree.get_child_elem("peripherals")?

--- a/src/svd/enumeratedvalue.rs
+++ b/src/svd/enumeratedvalue.rs
@@ -28,7 +28,7 @@ impl EnumeratedValue {
                 description: tree.get_child_text_opt("description")?,
                 // TODO: this .ok() approach is simple, but does not expose errors parsing child objects.
                 // Suggest refactoring all parse::type methods to return result so parse::optional works.
-                value: parse::optional("value", tree, parse::u32)?,
+                value: parse::optional("value", tree, u32::parse)?,
                 is_default: tree.get_child_bool("isDefault").ok(),
                 _extensible: (),
             },

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -55,12 +55,12 @@ impl RegisterInfo {
             description: tree.get_child_text("description")?,
             address_offset:
                 tree.get_child_u32("addressOffset")?,
-            size: parse::optional("size", tree, parse::u32)?,
+            size: parse::optional("size", tree, u32::parse)?,
             access: parse::optional("access", tree, Access::parse)?,
             reset_value:
-                parse::optional("resetValue", tree, parse::u32)?,
+                parse::optional("resetValue", tree, u32::parse)?,
             reset_mask:
-                parse::optional("resetMask", tree, parse::u32)?,
+                parse::optional("resetMask", tree, u32::parse)?,
             fields: {
                 if let Some(fields) = tree.get_child("fields") {
                         let fs: Result<Vec<_>, _> =


### PR DESCRIPTION
I was going to change the `fn u32(&Element)` to `fn u32(&str)` like the TODO says [here](https://github.com/japaric/svd/blob/refactor/src/parse.rs#L15) but then I noticed that the rest of the codebase uses [`parse::optional`](https://github.com/japaric/svd/blob/refactor/src/parse.rs#L63).

Because `parse::optional` expects `CB: 'static + Fn(&Element) -> Result<T, SVDError>`, I decided to just implement `impl Parse for u32`

This also allows us to change the `parse::optional` definition to:
```rust
pub fn optional<'a, T>(n: &str, e: &'a Element) -> Result<Option<T::Object>, SVDError>
    where T : Parse<Error = SVDError>
{
     let child = match e.get_child(n) {
        Some(c) => c,
        None => return Ok(None),
    };

    match CB::parse(child) {
        Ok(r) => Ok(Some(r)),
        Err(e) => Err(e),
    }
}
```
which would change the function call from:
```rust
parse::optional("size", tree, u32::parse)?;
```
to one of:
```rust
parse::optional::<u32>("size", tree)?;
parse::optional("size", tree)?;
```

( I'm willing to change the parse::optional implementation if that's something we want)