### PR TITLE
Applied requested changes to parse::optional

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,8 @@ pub enum SVDErrorKind {
     InvalidRegisterCluster(Element, String),
     #[fail(display = "Invalid modifiedWriteValues variant, found {}", _1)]
     InvalidModifiedWriteValues(Element, String),
+    #[fail(display = "The content of the element could not be parsed to a boolean value {}: {}", _1, _2)]
+    InvalidBooleanValue(Element, String, ::std::str::ParseBoolError),
     #[fail(display = "encoding method not implemented for svd object {}", _0)]
     EncodeNotImplemented(String),
     #[fail(display = "Error parsing SVD XML")]
@@ -72,7 +74,7 @@ impl Display for SVDError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(&self.inner, f)
     }
-} 
+}
 
 impl SVDError {
     pub fn kind(&self) -> SVDErrorKind {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl ElementExt for Element {
         String: PartialEq<K>,
         K: ::std::fmt::Display + Clone,
     {
-        self.get_child_text_opt(k.clone())?.ok_or(SVDErrorKind::MissingTag(self.clone(), format!("{}", k)).into())
+        self.get_child_text_opt(k.clone())?.ok_or(SVDErrorKind::MissingTag(self.clone(), format!("{}", k)).into(),)
     }
 
     /// Get text contained by an XML Element
@@ -93,7 +93,10 @@ impl ElementExt for Element {
             // FIXME: Doesn't look good because SVDErrorKind doesn't format by itself. We already
             // capture the element and this information can be used for getting the name
             // This would fix ParseError
-            None => Err(SVDErrorKind::EmptyTag(self.clone(), self.name.clone()).into()),
+            None => {
+                Err(SVDErrorKind::EmptyTag(self.clone(), self.name.clone())
+                    .into())
+            }
         }
     }
 
@@ -114,10 +117,7 @@ impl ElementExt for Element {
     /// Get a bool value from a named child element
     fn get_child_bool(&self, n: &str) -> Result<bool, SVDError> {
         let s = self.get_child_elem(n)?;
-        match BoolParse::parse(s)? {
-            Some(u) => Ok(u),
-            None => Err(SVDErrorKind::ParseError(self.clone()).into())
-        }
+        BoolParse::parse(s)
     }
 
     fn debug(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ use error::{SVDError, SVDErrorKind};
 
 pub mod parse;
 pub mod types;
+use parse::BoolParse;
 use types::Parse;
 
 /// Parses the contents of a SVD file (XML)
@@ -113,7 +114,7 @@ impl ElementExt for Element {
     /// Get a bool value from a named child element
     fn get_child_bool(&self, n: &str) -> Result<bool, SVDError> {
         let s = self.get_child_elem(n)?;
-        match parse::bool(s) {
+        match BoolParse::parse(s)? {
             Some(u) => Ok(u),
             None => Err(SVDErrorKind::ParseError(self.clone()).into())
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,8 @@
 use xmltree::Element;
 
 use error::*;
+use types::Parse;
+use ElementExt;
 
 macro_rules! try {
     ($e:expr) => {
@@ -8,42 +10,55 @@ macro_rules! try {
     }
 }
 
-pub fn bool(tree: &Element) -> Option<bool> {
-    let text = try!(tree.text.as_ref());
-    match text.as_ref() {
-        "0" => Some(false),
-        "1" => Some(true),
-        _ => text.parse::<bool>().ok()
+pub struct BoolParse;
+
+impl Parse for BoolParse {
+    type Object = Option<bool>;
+    type Error = SVDError;
+    fn parse(tree: &Element) -> Result<Option<bool>, SVDError> {
+        let text = try!(tree.text.as_ref());
+        Ok(match text.as_ref() {
+            "0" => Some(false),
+            "1" => Some(true),
+            _ => text.parse::<bool>().ok()
+        })
     }
 }
 
-pub fn dim_index(text: &str) -> Result<Vec<String>, SVDError> {
-    if text.contains('-') {
-        let mut parts = text.splitn(2, '-');
-        let start = try!(try!(parts.next()).parse::<u32>());
-        let end = try!(try!(parts.next()).parse::<u32>()) + 1;
+pub struct DimIndex;
 
-        Ok((start..end).map(|i| i.to_string()).collect())
-    } else if text.contains(',') {
-        Ok(text.split(',').map(|s| s.to_string()).collect())
-    } else {
-        unreachable!()
-    }
-}
+impl Parse for DimIndex {
+    type Object = Vec<String>;
+    type Error = SVDError;
 
+    fn parse(tree: &Element) -> Result<Vec<String>, SVDError> {
+        let text = tree.get_text()?;
+        if text.contains('-') {
+            let mut parts = text.splitn(2, '-');
+            let start = try!(try!(parts.next()).parse::<u32>());
+            let end = try!(try!(parts.next()).parse::<u32>()) + 1;
+
+            Ok((start..end).map(|i| i.to_string()).collect())
+        } else if text.contains(',') {
+            Ok(text.split(',').map(|s| s.to_string()).collect())
+        } else {
+            unreachable!()
+        }
+     }
+ }
 /// Parses an optional child element with the provided name and Parse function
 /// Returns an none if the child doesn't exist, Ok(Some(e)) if parsing succeeds,
 /// and Err() if parsing fails.
 /// TODO: suspect we should be able to use the Parse trait here
-pub fn optional<'a, T, CB>(n: &str, e: &'a Element, f: CB) -> Result<Option<T>, SVDError>
-    where CB: 'static + Fn(&Element) -> Result<T, SVDError>
+pub fn optional<'a, T>(n: &str, e: &'a Element) -> Result<Option<T::Object>, SVDError>
+    where T: Parse<Error = SVDError>
 {
      let child = match e.get_child(n) {
         Some(c) => c,
         None => return Ok(None),
     };
 
-    match f(child) {
+    match T::parse(child) {
         Ok(r) => Ok(Some(r)),
         Err(e) => Err(e),
     }

--- a/src/svd/clusterinfo.rs
+++ b/src/svd/clusterinfo.rs
@@ -37,13 +37,13 @@ impl Parse for ClusterInfo {
             header_struct_name: tree.get_child_text_opt("headerStructName")?,
             address_offset: 
                 tree.get_child_u32("addressOffset")?,
-            size: parse::optional("size", tree, u32::parse)?,
+            size: parse::optional::<u32>("size", tree)?,
             //access: tree.get_child("access").map(|t| Access::parse(t).ok() ),
-            access: parse::optional("access", tree, Access::parse)?,
+            access: parse::optional::<Access>("access", tree)?,
             reset_value:
-                parse::optional("resetValue", tree, u32::parse)?,
+                parse::optional::<u32>("resetValue", tree)?,
             reset_mask:
-                parse::optional("resetMask", tree, u32::parse)?,
+                parse::optional::<u32>("resetMask", tree)?,
             children: {
                 let children: Result<Vec<_>,_> = tree.children
                     .iter()

--- a/src/svd/defaults.rs
+++ b/src/svd/defaults.rs
@@ -23,10 +23,10 @@ impl Parse for Defaults {
 
     fn parse(tree: &Element) -> Result<Defaults, SVDError> {
         Ok(Defaults {
-            size: parse::optional("size", tree, u32::parse)?,
-            reset_value: parse::optional("resetValue", tree, u32::parse)?,
-            reset_mask: parse::optional("resetMask", tree, u32::parse)?,
-            access: parse::optional("access", tree, Access::parse).unwrap(),
+            size: parse::optional::<u32>("size", tree)?,
+            reset_value: parse::optional::<u32>("resetValue", tree)?,
+            reset_mask: parse::optional::<u32>("resetMask", tree)?,
+            access: parse::optional::<Access>("access", tree)?,
             _extensible: (),
         })
     }

--- a/src/svd/device.rs
+++ b/src/svd/device.rs
@@ -34,10 +34,10 @@ impl Parse for Device {
         Ok(Device {
             name: tree.get_child_text("name")?,
             schema_version: tree.attributes.get("schemaVersion").unwrap().clone(),
-            cpu: parse::optional("cpu", tree, Cpu::parse)?,
+            cpu: parse::optional::<Cpu>("cpu", tree)?,
             version: tree.get_child_text_opt("version")?,
             description: tree.get_child_text_opt("description")?,
-            address_unit_bits: parse::optional("addressUnitBits", tree, u32::parse)?,
+            address_unit_bits: parse::optional::<u32>("addressUnitBits", tree)?,
             width: None,
             peripherals: {
                 let ps: Result<Vec<_>, _> = tree.get_child_elem("peripherals")?

--- a/src/svd/enumeratedvalue.rs
+++ b/src/svd/enumeratedvalue.rs
@@ -28,7 +28,7 @@ impl EnumeratedValue {
                 description: tree.get_child_text_opt("description")?,
                 // TODO: this .ok() approach is simple, but does not expose errors parsing child objects.
                 // Suggest refactoring all parse::type methods to return result so parse::optional works.
-                value: parse::optional("value", tree, u32::parse)?,
+                value: parse::optional::<u32>("value", tree)?,
                 is_default: tree.get_child_bool("isDefault").ok(),
                 _extensible: (),
             },

--- a/src/svd/enumeratedvalues.rs
+++ b/src/svd/enumeratedvalues.rs
@@ -31,7 +31,7 @@ impl Parse for EnumeratedValues {
 
         Ok(EnumeratedValues {
             name: tree.get_child_text_opt("name")?,
-            usage: parse::optional("usage", tree, Usage::parse)?,
+            usage: parse::optional::<Usage>("usage", tree)?,
             derived_from: tree.attributes
                 .get(&"derivedFrom".to_owned())
                 .map(|s| s.to_owned()),

--- a/src/svd/field.rs
+++ b/src/svd/field.rs
@@ -47,7 +47,7 @@ impl Field {
             name,
             description: tree.get_child_text_opt("description")?,
             bit_range: BitRange::parse(tree)?,
-            access: parse::optional("access", tree, Access::parse)?,
+            access: parse::optional::<Access>("access", tree)?,
             enumerated_values: {
                 let values: Result<Vec<_>,_> = tree.children
                     .iter()
@@ -56,8 +56,8 @@ impl Field {
                     .collect();
                 values?
             },
-            write_constraint: parse::optional("writeConstraint", tree, WriteConstraint::parse)?,
-            modified_write_values: parse::optional("modifiedWriteValues", tree, ModifiedWriteValues::parse)?,
+            write_constraint: parse::optional::<WriteConstraint>("writeConstraint", tree)?,
+            modified_write_values: parse::optional::<ModifiedWriteValues>("modifiedWriteValues", tree)?,
             _extensible: (),
         })
     }

--- a/src/svd/peripheral.rs
+++ b/src/svd/peripheral.rs
@@ -63,7 +63,7 @@ impl Peripheral {
             group_name: tree.get_child_text_opt("groupName")?,
             description: tree.get_child_text_opt("description")?,
             base_address: tree.get_child_u32("baseAddress")?,
-            address_block: parse::optional("addressBlock", tree, AddressBlock::parse)?,
+            address_block: parse::optional::<AddressBlock>("addressBlock", tree)?,
             interrupt: {
                 let interrupt: Result<Vec<_>,_> = tree.children
                     .iter()

--- a/src/svd/registerclusterarrayinfo.rs
+++ b/src/svd/registerclusterarrayinfo.rs
@@ -22,9 +22,7 @@ impl Parse for RegisterClusterArrayInfo {
         Ok(RegisterClusterArrayInfo {
             dim: tree.get_child_u32("dim")?,
             dim_increment: tree.get_child_u32("dimIncrement")?,
-            dim_index: parse::optional("dimIndex", tree, |c| {
-                parse::dim_index(&c.get_text()?)
-            })?,
+            dim_index: parse::optional::<parse::DimIndex>("dimIndex", tree)?,
         })
     }
 }

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -55,12 +55,12 @@ impl RegisterInfo {
             description: tree.get_child_text("description")?,
             address_offset:
                 tree.get_child_u32("addressOffset")?,
-            size: parse::optional("size", tree, u32::parse)?,
-            access: parse::optional("access", tree, Access::parse)?,
+            size: parse::optional::<u32>("size", tree)?,
+            access: parse::optional::<Access>("access", tree)?,
             reset_value:
-                parse::optional("resetValue", tree, u32::parse)?,
+                parse::optional::<u32>("resetValue", tree)?,
             reset_mask:
-                parse::optional("resetMask", tree, u32::parse)?,
+                parse::optional::<u32>("resetMask", tree)?,
             fields: {
                 if let Some(fields) = tree.get_child("fields") {
                         let fs: Result<Vec<_>, _> =
@@ -74,8 +74,8 @@ impl RegisterInfo {
                     None
                 }
             },
-            write_constraint: parse::optional("writeConstraint", tree, WriteConstraint::parse)?,
-            modified_write_values: parse::optional("modifiedWriteValues", tree, ModifiedWriteValues::parse)?,
+            write_constraint: parse::optional::<WriteConstraint>("writeConstraint", tree)?,
+            modified_write_values: parse::optional::<ModifiedWriteValues>("modifiedWriteValues", tree)?,
             _extensible: (),
         })
     }

--- a/tests/bad_svd.rs
+++ b/tests/bad_svd.rs
@@ -1,7 +1,6 @@
 extern crate svd_parser as svd;
 extern crate failure;
 
-use svd::error as err;
 use failure::Fail;
 
 #[test]


### PR DESCRIPTION
Applied the requested changes in #55.

As it turns out, `parse::optional` does not get used in combination with `bool`.

I have made a `BoolParse` struct that implements parse, but because `pub fn bool(tree: &Element)` returned `Option<bool>`, this makes `parse::optional` return `Option<Option<bool>>`.

One way to fix this is to put more logic in the `Parse` trait that returns an optional by default, like so:

```rust
/// Parse trait allows SVD objects to be parsed from XML elements.
pub trait Parse {
    /// Object returned by parse method
    type Object;
    /// Parsing error
    type Error;
    /// Parse an XML/SVD element into it's corresponding `Object`.
    fn parse(&Element) -> Result<Self::Object, Self::Error>;

    /// Parse an XML/SVD element into it's corresponding `Option<Object>`.
    fn parse_optional(&Element) -> Result<Option<Self::Object>, Self::Error> {
        match Self::parse(child) {
            Ok(r) => Ok(Some(r)),
            Err(e) => Err(e),
        }
    }
}
```

In this situation, the `BoolParse` struct can overwrite the `parse_optional` fn to make sure the `Option` does not get doubled.