### PR TITLE
encode/field: only generate a description element when present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.rs.bk
-[._]*.sw[a-p]
+.#*
 Cargo.lock
+[._]*.sw[a-p]
 target
 tests/

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,0 @@
-array_layout = "Block"
-fn_args_layout = "Block"
-fn_call_style = "Block"
-generics_indent = "Block"
-max_width = 80
-where_style = "Rfc"
-write_mode = "overwrite"

--- a/src/elementext.rs
+++ b/src/elementext.rs
@@ -36,9 +36,7 @@ impl ElementExt for Element {
         String: PartialEq<K>,
     {
         if let Some(child) = self.get_child(k) {
-            Ok(Some(child
-                .get_text()
-                .map(|s| s.to_owned())?))
+            Ok(Some(child.get_text().map(|s| s.to_owned())?))
         } else {
             Ok(None)
         }
@@ -48,9 +46,8 @@ impl ElementExt for Element {
         String: PartialEq<K>,
         K: ::std::fmt::Display + Clone,
     {
-        self.get_child_text_opt(k.clone())?.ok_or(
-            SVDErrorKind::MissingTag(self.clone(), format!("{}", k)).into(),
-        )
+        self.get_child_text_opt(k.clone())?
+            .ok_or(SVDErrorKind::MissingTag(self.clone(), format!("{}", k)).into())
     }
 
     /// Get text contained by an XML Element
@@ -60,10 +57,7 @@ impl ElementExt for Element {
             // FIXME: Doesn't look good because SVDErrorKind doesn't format by itself. We already
             // capture the element and this information can be used for getting the name
             // This would fix ParseError
-            None => Err(SVDErrorKind::EmptyTag(
-                self.clone(),
-                self.name.clone(),
-            ).into()),
+            None => Err(SVDErrorKind::EmptyTag(self.clone(), self.name.clone()).into()),
         }
     }
 
@@ -71,9 +65,7 @@ impl ElementExt for Element {
     fn get_child_elem<'a>(&'a self, n: &str) -> Result<&'a Element, SVDError> {
         match self.get_child(n) {
             Some(s) => Ok(s),
-            None => Err(
-                SVDErrorKind::MissingTag(self.clone(), n.to_string()).into(),
-            ),
+            None => Err(SVDErrorKind::MissingTag(self.clone(), n.to_string()).into()),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,8 +47,7 @@ pub enum SVDErrorKind {
     InvalidModifiedWriteValues(Element, String),
     #[fail(
         display = "The content of the element could not be parsed to a boolean value {}: {}",
-        _1,
-        _2
+        _1, _2
     )]
     InvalidBooleanValue(Element, String, ::std::str::ParseBoolError),
     #[fail(display = "encoding method not implemented for svd object {}", _0)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,10 +95,7 @@ pub(crate) fn new_element(name: &str, text: Option<String>) -> Element {
 #[cfg(test)]
 #[cfg(feature = "unproven")]
 pub fn run_test<
-    T: Parse<Error = SVDError, Object = T>
-        + Encode<Error = SVDError>
-        + ::std::fmt::Debug
-        + PartialEq,
+    T: Parse<Error = SVDError, Object = T> + Encode<Error = SVDError> + ::std::fmt::Debug + PartialEq,
 >(
     tests: &[(T, &str)],
 ) {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -18,10 +18,7 @@ pub trait Parse {
 /// Parses an optional child element with the provided name and Parse function
 /// Returns an none if the child doesn't exist, Ok(Some(e)) if parsing succeeds,
 /// and Err() if parsing fails.
-pub fn optional<'a, T>(
-    n: &str,
-    e: &'a Element,
-) -> Result<Option<T::Object>, SVDError>
+pub fn optional<'a, T>(n: &str, e: &'a Element) -> Result<Option<T::Object>, SVDError>
 where
     T: Parse<Error = SVDError>,
 {

--- a/src/svd/access.rs
+++ b/src/svd/access.rs
@@ -63,10 +63,7 @@ mod tests {
         let tests = vec![
             (Access::ReadOnly, "<access>read-only</access>"),
             (Access::ReadWrite, "<access>read-write</access>"),
-            (
-                Access::ReadWriteOnce,
-                "<access>read-writeOnce</access>",
-            ),
+            (Access::ReadWriteOnce, "<access>read-writeOnce</access>"),
             (Access::WriteOnly, "<access>write-only</access>"),
             (Access::WriteOnce, "<access>writeOnce</access>"),
         ];

--- a/src/svd/bitrange.rs
+++ b/src/svd/bitrange.rs
@@ -25,9 +25,7 @@ impl Parse for BitRange {
     type Error = SVDError;
 
     fn parse(tree: &Element) -> Result<BitRange, SVDError> {
-        let (end, start, range_type): (u32, u32, BitRangeType) = if let Some(
-            range,
-        ) =
+        let (end, start, range_type): (u32, u32, BitRangeType) = if let Some(range) =
             tree.get_child("bitRange")
         {
             let text = range
@@ -37,16 +35,14 @@ impl Parse for BitRange {
                                                                        // TODO: If the `InvalidBitRange` enum was an error we could context into here somehow so that
                                                                        // the output would be similar to the parse error
             if !text.starts_with('[') {
-                return Err(SVDErrorKind::InvalidBitRange(
-                    tree.clone(),
-                    InvalidBitRange::Syntax,
-                ).into()); // TODO: Maybe have a MissingOpen/MissingClosing variant
+                return Err(
+                    SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::Syntax).into(),
+                ); // TODO: Maybe have a MissingOpen/MissingClosing variant
             }
             if !text.ends_with(']') {
-                return Err(SVDErrorKind::InvalidBitRange(
-                    tree.clone(),
-                    InvalidBitRange::Syntax,
-                ).into()); // TODO: Maybe have a MissingOpen/MissingClosing variant
+                return Err(
+                    SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::Syntax).into(),
+                ); // TODO: Maybe have a MissingOpen/MissingClosing variant
             }
 
             let mut parts = text[1..text.len() - 1].split(':');
@@ -76,9 +72,7 @@ impl Parse for BitRange {
                 BitRangeType::BitRange,
             )
         // TODO: Consider matching instead so we can say which of these tags are missing
-        } else if let (Some(lsb), Some(msb)) =
-            (tree.get_child("lsb"), tree.get_child("msb"))
-        {
+        } else if let (Some(lsb), Some(msb)) = (tree.get_child("lsb"), tree.get_child("msb")) {
             (
                 // TODO: `u32::parse` should not hide it's errors
                 u32::parse(msb).context(SVDErrorKind::InvalidBitRange(
@@ -91,26 +85,28 @@ impl Parse for BitRange {
                 ))?,
                 BitRangeType::MsbLsb,
             )
-        } else if let (Some(offset), Some(width)) = (
-            tree.get_child("bitOffset"),
-            tree.get_child("bitWidth"),
-        ) {
+        } else if let (Some(offset), Some(width)) =
+            (tree.get_child("bitOffset"), tree.get_child("bitWidth"))
+        {
             (
                 // Special case because offset and width are directly provided
                 // (ie. do not need to be calculated as in the final step)
                 return Ok(BitRange {
                     // TODO: capture that error comes from offset/width tag
                     // TODO: `u32::parse` should not hide it's errors
-                    offset: u32::parse(offset).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::ParseError))?, 
-                    width: u32::parse(width).context(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::ParseError))?, 
-                    range_type: BitRangeType::OffsetWidth
+                    offset: u32::parse(offset).context(SVDErrorKind::InvalidBitRange(
+                        tree.clone(),
+                        InvalidBitRange::ParseError,
+                    ))?,
+                    width: u32::parse(width).context(SVDErrorKind::InvalidBitRange(
+                        tree.clone(),
+                        InvalidBitRange::ParseError,
+                    ))?,
+                    range_type: BitRangeType::OffsetWidth,
                 })
             )
         } else {
-            return Err(SVDErrorKind::InvalidBitRange(
-                tree.clone(),
-                InvalidBitRange::Syntax,
-            ).into());
+            return Err(SVDErrorKind::InvalidBitRange(tree.clone(), InvalidBitRange::Syntax).into());
         };
 
         Ok(BitRange {
@@ -135,10 +131,7 @@ impl BitRange {
             )]),
             BitRangeType::MsbLsb => Ok(vec![
                 new_element("lsb", Some(format!("{}", self.offset))),
-                new_element(
-                    "msb",
-                    Some(format!("{}", self.offset + self.width - 1)),
-                ),
+                new_element("msb", Some(format!("{}", self.offset + self.width - 1))),
             ]),
             BitRangeType::OffsetWidth => Ok(vec![
                 new_element("bitOffset", Some(format!("{}", self.offset))),

--- a/src/svd/clusterinfo.rs
+++ b/src/svd/clusterinfo.rs
@@ -44,7 +44,8 @@ impl Parse for ClusterInfo {
             reset_value: parse::optional::<u32>("resetValue", tree)?,
             reset_mask: parse::optional::<u32>("resetMask", tree)?,
             children: {
-                let children: Result<Vec<_>, _> = tree.children
+                let children: Result<Vec<_>, _> = tree
+                    .children
                     .iter()
                     .filter(|t| t.name == "register" || t.name == "cluster")
                     .map(RegisterCluster::parse)
@@ -62,10 +63,8 @@ impl Encode for ClusterInfo {
     fn encode(&self) -> Result<Element, SVDError> {
         let mut e = new_element("cluster", None);
 
-        e.children.push(new_element(
-            "description",
-            Some(self.description.clone()),
-        ));
+        e.children
+            .push(new_element("description", Some(self.description.clone())));
 
         if let Some(ref v) = self.header_struct_name {
             e.children
@@ -78,8 +77,7 @@ impl Encode for ClusterInfo {
         ));
 
         if let Some(ref v) = self.size {
-            e.children
-                .push(new_element("size", Some(format!("{}", v))));
+            e.children.push(new_element("size", Some(format!("{}", v))));
         }
 
         if let Some(ref v) = self.access {
@@ -87,10 +85,8 @@ impl Encode for ClusterInfo {
         }
 
         if let Some(ref v) = self.reset_value {
-            e.children.push(new_element(
-                "resetValue",
-                Some(format!("{}", v)),
-            ));
+            e.children
+                .push(new_element("resetValue", Some(format!("{}", v))));
         }
 
         if let Some(ref v) = self.reset_mask {

--- a/src/svd/cpu.rs
+++ b/src/svd/cpu.rs
@@ -60,18 +60,9 @@ impl Encode for Cpu {
                 new_element("name", Some(self.name.clone())),
                 new_element("revision", Some(self.revision.clone())),
                 self.endian.encode()?,
-                new_element(
-                    "mpuPresent",
-                    Some(format!("{}", self.mpu_present)),
-                ),
-                new_element(
-                    "fpuPresent",
-                    Some(format!("{}", self.fpu_present)),
-                ),
-                new_element(
-                    "nvicPrioBits",
-                    Some(format!("{}", self.nvic_priority_bits)),
-                ),
+                new_element("mpuPresent", Some(format!("{}", self.mpu_present))),
+                new_element("fpuPresent", Some(format!("{}", self.fpu_present))),
+                new_element("nvicPrioBits", Some(format!("{}", self.nvic_priority_bits))),
                 new_element(
                     "vendorSystickConfig",
                     Some(format!("{}", self.has_vendor_systick)),

--- a/src/svd/defaults.rs
+++ b/src/svd/defaults.rs
@@ -46,30 +46,21 @@ impl EncodeChildren for Defaults {
 
         match self.size {
             Some(ref v) => {
-                children.push(new_element(
-                    "size",
-                    Some(format!("0x{:08.x}", v)),
-                ));
+                children.push(new_element("size", Some(format!("0x{:08.x}", v))));
             }
             None => (),
         };
 
         match self.reset_value {
             Some(ref v) => {
-                children.push(new_element(
-                    "resetValue",
-                    Some(format!("0x{:08.x}", v)),
-                ));
+                children.push(new_element("resetValue", Some(format!("0x{:08.x}", v))));
             }
             None => (),
         };
 
         match self.reset_mask {
             Some(ref v) => {
-                children.push(new_element(
-                    "resetMask",
-                    Some(format!("0x{:08.x}", v)),
-                ));
+                children.push(new_element("resetMask", Some(format!("0x{:08.x}", v))));
             }
             None => (),
         };

--- a/src/svd/device.rs
+++ b/src/svd/device.rs
@@ -38,17 +38,15 @@ impl Parse for Device {
     fn parse(tree: &Element) -> Result<Device, SVDError> {
         Ok(Device {
             name: tree.get_child_text("name")?,
-            schema_version: tree.attributes
-                .get("schemaVersion")
-                .unwrap()
-                .clone(),
+            schema_version: tree.attributes.get("schemaVersion").unwrap().clone(),
             cpu: parse::optional::<Cpu>("cpu", tree)?,
             version: tree.get_child_text_opt("version")?,
             description: tree.get_child_text_opt("description")?,
             address_unit_bits: parse::optional::<u32>("addressUnitBits", tree)?,
             width: None,
             peripherals: {
-                let ps: Result<Vec<_>, _> = tree.get_child_elem("peripherals")?
+                let ps: Result<Vec<_>, _> = tree
+                    .get_child_elem("peripherals")?
                     .children
                     .iter()
                     .map(Peripheral::parse)
@@ -87,27 +85,27 @@ impl Encode for Device {
         );
 
         match self.version {
-            Some(ref v) => elem.children
-                .push(new_element("version", Some(v.clone()))),
+            Some(ref v) => elem.children.push(new_element("version", Some(v.clone()))),
             None => (),
         }
 
         match self.description {
-            Some(ref v) => elem.children
+            Some(ref v) => elem
+                .children
                 .push(new_element("description", Some(v.clone()))),
             None => (),
         }
 
         match self.description {
-            Some(ref v) => elem.children.push(new_element(
-                "addressUnitBits",
-                Some(format!("{}", v)),
-            )),
+            Some(ref v) => elem
+                .children
+                .push(new_element("addressUnitBits", Some(format!("{}", v)))),
             None => (),
         }
 
         match self.width {
-            Some(ref v) => elem.children
+            Some(ref v) => elem
+                .children
                 .push(new_element("width", Some(format!("{}", v)))),
             None => (),
         }
@@ -119,10 +117,8 @@ impl Encode for Device {
             None => (),
         }
 
-        let peripherals: Result<Vec<_>, _> = self.peripherals
-            .iter()
-            .map(Peripheral::encode)
-            .collect();
+        let peripherals: Result<Vec<_>, _> =
+            self.peripherals.iter().map(Peripheral::encode).collect();
         elem.children.push(Element {
             name: String::from("peripherals"),
             attributes: HashMap::new(),

--- a/src/svd/endian.rs
+++ b/src/svd/endian.rs
@@ -67,10 +67,7 @@ mod tests {
         let tests = vec![
             (Endian::Little, "<endian>little</endian>"),
             (Endian::Big, "<endian>big</endian>"),
-            (
-                Endian::Selectable,
-                "<endian>selectable</endian>",
-            ),
+            (Endian::Selectable, "<endian>selectable</endian>"),
             (Endian::Other, "<endian>other</endian>"),
         ];
 

--- a/src/svd/enumeratedvalue.rs
+++ b/src/svd/enumeratedvalue.rs
@@ -23,10 +23,7 @@ pub struct EnumeratedValue {
     pub(crate) _extensible: (),
 }
 impl EnumeratedValue {
-    fn _parse(
-        tree: &Element,
-        name: String,
-    ) -> Result<EnumeratedValue, SVDError> {
+    fn _parse(tree: &Element, name: String) -> Result<EnumeratedValue, SVDError> {
         Ok(EnumeratedValue {
             name,
             description: tree.get_child_text_opt("description")?,
@@ -44,10 +41,9 @@ impl Parse for EnumeratedValue {
 
     fn parse(tree: &Element) -> Result<EnumeratedValue, SVDError> {
         if tree.name != "enumeratedValue" {
-            return Err(SVDErrorKind::NotExpectedTag(
-                tree.clone(),
-                format!("enumeratedValue"),
-            ).into());
+            return Err(
+                SVDErrorKind::NotExpectedTag(tree.clone(), format!("enumeratedValue")).into(),
+            );
         }
         let name = tree.get_child_text("name")?;
         EnumeratedValue::_parse(tree, name.clone())
@@ -74,18 +70,15 @@ impl Encode for EnumeratedValue {
         match self.description {
             Some(ref d) => {
                 let s = (*d).clone();
-                base.children
-                    .push(new_element("description", Some(s)));
+                base.children.push(new_element("description", Some(s)));
             }
             None => (),
         };
 
         match self.value {
             Some(ref v) => {
-                base.children.push(new_element(
-                    "value",
-                    Some(format!("0x{:08.x}", *v)),
-                ));
+                base.children
+                    .push(new_element("value", Some(format!("0x{:08.x}", *v))));
             }
             None => (),
         };
@@ -110,8 +103,8 @@ mod tests {
 
     #[test]
     fn decode_encode() {
-        let tests = vec![
-            (EnumeratedValue {
+        let tests = vec![(
+            EnumeratedValue {
                 name: String::from("WS0"),
                 description: Some(String::from(
                     "Zero wait-states inserted in fetch or read transfers",
@@ -127,8 +120,8 @@ mod tests {
                     <value>0x00000000</value>
                     <isDefault>true</isDefault>
                 </enumeratedValue>
-            ")
-        ];
+            ",
+        )];
 
         run_test::<EnumeratedValue>(&tests[..]);
     }

--- a/src/svd/enumeratedvalues.rs
+++ b/src/svd/enumeratedvalues.rs
@@ -35,11 +35,13 @@ impl Parse for EnumeratedValues {
         Ok(EnumeratedValues {
             name: tree.get_child_text_opt("name")?,
             usage: parse::optional::<Usage>("usage", tree)?,
-            derived_from: tree.attributes
+            derived_from: tree
+                .attributes
                 .get(&"derivedFrom".to_owned())
                 .map(|s| s.to_owned()),
             values: {
-                let values: Result<Vec<_>, _> = tree.children
+                let values: Result<Vec<_>, _> = tree
+                    .children
                     .iter()
                     .filter(|t| t.name == "enumeratedValue")
                     .enumerate()
@@ -70,8 +72,7 @@ impl Encode for EnumeratedValues {
 
         match self.name {
             Some(ref d) => {
-                base.children
-                    .push(new_element("name", Some((*d).clone())));
+                base.children.push(new_element("name", Some((*d).clone())));
             }
             None => (),
         };

--- a/src/svd/field.rs
+++ b/src/svd/field.rs
@@ -37,17 +37,11 @@ impl Parse for Field {
     type Error = SVDError;
     fn parse(tree: &Element) -> Result<Field, SVDError> {
         if tree.name != "field" {
-            return Err(SVDErrorKind::NotExpectedTag(
-                tree.clone(),
-                format!("field"),
-            ).into());
+            return Err(SVDErrorKind::NotExpectedTag(tree.clone(), format!("field")).into());
         }
         let name = tree.get_child_text("name")?;
         Field::_parse(tree, name.clone())
-            .context(SVDErrorKind::Other(format!(
-                "In field `{}`",
-                name
-            )))
+            .context(SVDErrorKind::Other(format!("In field `{}`", name)))
             .map_err(|e| e.into())
     }
 }
@@ -60,17 +54,15 @@ impl Field {
             bit_range: BitRange::parse(tree)?,
             access: parse::optional::<Access>("access", tree)?,
             enumerated_values: {
-                let values: Result<Vec<_>, _> = tree.children
+                let values: Result<Vec<_>, _> = tree
+                    .children
                     .iter()
                     .filter(|t| t.name == "enumeratedValues")
                     .map(EnumeratedValues::parse)
                     .collect();
                 values?
             },
-            write_constraint: parse::optional::<WriteConstraint>(
-                "writeConstraint",
-                tree,
-            )?,
+            write_constraint: parse::optional::<WriteConstraint>("writeConstraint", tree)?,
             modified_write_values: parse::optional::<ModifiedWriteValues>(
                 "modifiedWriteValues",
                 tree,
@@ -95,8 +87,7 @@ impl Encode for Field {
         };
 
         // Add bit range
-        elem.children
-            .append(&mut self.bit_range.encode()?);
+        elem.children.append(&mut self.bit_range.encode()?);
 
         match self.access {
             Some(ref v) => {
@@ -106,10 +97,7 @@ impl Encode for Field {
         };
 
         let enumerated_values: Result<Vec<Element>, SVDError> =
-            self.enumerated_values
-                .iter()
-                .map(|v| v.encode())
-                .collect();
+            self.enumerated_values.iter().map(|v| v.encode()).collect();
         elem.children.append(&mut enumerated_values?);
 
         match self.write_constraint {
@@ -140,41 +128,36 @@ mod tests {
 
     #[test]
     fn decode_encode() {
-        let tests = vec![
-            (
-                Field {
-                    name: String::from("MODE"),
-                    description: Some(String::from("Read Mode")),
-                    bit_range: BitRange {
-                        offset: 24,
-                        width: 2,
-                        range_type: BitRangeType::OffsetWidth,
-                    },
-                    access: Some(Access::ReadWrite),
-                    enumerated_values: vec![
-                        EnumeratedValues {
-                            name: None,
-                            usage: None,
-                            derived_from: None,
-                            values: vec![
-                                EnumeratedValue {
-                                    name: String::from("WS0"),
-                                    description: Some(String::from(
-                                        "Zero wait-states inserted in fetch or read transfers",
-                                    )),
-                                    value: Some(0),
-                                    is_default: None,
-                                    _extensible: (),
-                                },
-                            ],
-                            _extensible: (),
-                        },
-                    ],
-                    write_constraint: None,
-                    modified_write_values: None,
-                    _extensible: (),
+        let tests = vec![(
+            Field {
+                name: String::from("MODE"),
+                description: Some(String::from("Read Mode")),
+                bit_range: BitRange {
+                    offset: 24,
+                    width: 2,
+                    range_type: BitRangeType::OffsetWidth,
                 },
-                "
+                access: Some(Access::ReadWrite),
+                enumerated_values: vec![EnumeratedValues {
+                    name: None,
+                    usage: None,
+                    derived_from: None,
+                    values: vec![EnumeratedValue {
+                        name: String::from("WS0"),
+                        description: Some(String::from(
+                            "Zero wait-states inserted in fetch or read transfers",
+                        )),
+                        value: Some(0),
+                        is_default: None,
+                        _extensible: (),
+                    }],
+                    _extensible: (),
+                }],
+                write_constraint: None,
+                modified_write_values: None,
+                _extensible: (),
+            },
+            "
             <field>
               <name>MODE</name>
               <description>Read Mode</description>
@@ -189,9 +172,8 @@ mod tests {
                 </enumeratedValue>
               </enumeratedValues>
             </field>
-            "
-            ),
-        ];
+            ",
+        )];
 
         run_test::<Field>(&tests[..]);
     }

--- a/src/svd/interrupt.rs
+++ b/src/svd/interrupt.rs
@@ -35,17 +35,11 @@ impl Parse for Interrupt {
     type Error = SVDError;
     fn parse(tree: &Element) -> Result<Interrupt, SVDError> {
         if tree.name != "interrupt" {
-            return Err(SVDErrorKind::NotExpectedTag(
-                tree.clone(),
-                format!("interrupt"),
-            ).into());
+            return Err(SVDErrorKind::NotExpectedTag(tree.clone(), format!("interrupt")).into());
         }
         let name = tree.get_child_text("name")?;
         Interrupt::_parse(tree, name.clone())
-            .context(SVDErrorKind::Other(format!(
-                "In interrupt `{}`",
-                name
-            )))
+            .context(SVDErrorKind::Other(format!("In interrupt `{}`", name)))
             .map_err(|e| e.into())
     }
 }

--- a/src/svd/modifiedwritevalues.rs
+++ b/src/svd/modifiedwritevalues.rs
@@ -39,10 +39,7 @@ impl Parse for ModifiedWriteValues {
             "set" => Set,
             "modify" => Modify,
             s => {
-                return Err(SVDErrorKind::InvalidModifiedWriteValues(
-                    tree.clone(),
-                    s.into(),
-                ).into())
+                return Err(SVDErrorKind::InvalidModifiedWriteValues(tree.clone(), s.into()).into())
             }
         })
     }

--- a/src/svd/peripheral.rs
+++ b/src/svd/peripheral.rs
@@ -41,17 +41,11 @@ impl Parse for Peripheral {
 
     fn parse(tree: &Element) -> Result<Peripheral, SVDError> {
         if tree.name != "peripheral" {
-            return Err(SVDErrorKind::NotExpectedTag(
-                tree.clone(),
-                format!("peripheral"),
-            ).into());
+            return Err(SVDErrorKind::NotExpectedTag(tree.clone(), format!("peripheral")).into());
         }
         let name = tree.get_child_text("name")?;
         Peripheral::_parse(tree, name.clone())
-            .context(SVDErrorKind::Other(format!(
-                "In peripheral `{}`",
-                name
-            )))
+            .context(SVDErrorKind::Other(format!("In peripheral `{}`", name)))
             .map_err(|e| e.into())
     }
 }
@@ -59,15 +53,9 @@ impl Parse for Peripheral {
 impl Peripheral {
     pub fn derive_from(&self, other: &Peripheral) -> Peripheral {
         let mut derived = self.clone();
-        derived.group_name = derived
-            .group_name
-            .or_else(|| other.group_name.clone());
-        derived.description = derived
-            .description
-            .or_else(|| other.description.clone());
-        derived.registers = derived
-            .registers
-            .or_else(|| other.registers.clone());
+        derived.group_name = derived.group_name.or_else(|| other.group_name.clone());
+        derived.description = derived.description.or_else(|| other.description.clone());
+        derived.registers = derived.registers.or_else(|| other.registers.clone());
         if derived.interrupt.is_empty() {
             derived.interrupt = other.interrupt.clone();
         }
@@ -82,12 +70,10 @@ impl Peripheral {
             group_name: tree.get_child_text_opt("groupName")?,
             description: tree.get_child_text_opt("description")?,
             base_address: tree.get_child_u32("baseAddress")?,
-            address_block: parse::optional::<AddressBlock>(
-                "addressBlock",
-                tree,
-            )?,
+            address_block: parse::optional::<AddressBlock>("addressBlock", tree)?,
             interrupt: {
-                let interrupt: Result<Vec<_>, _> = tree.children
+                let interrupt: Result<Vec<_>, _> = tree
+                    .children
                     .iter()
                     .filter(|t| t.name == "interrupt")
                     .enumerate()
@@ -109,9 +95,7 @@ impl Peripheral {
             } else {
                 None
             },
-            derived_from: tree.attributes
-                .get("derivedFrom")
-                .map(|s| s.to_owned()),
+            derived_from: tree.attributes.get("derivedFrom").map(|s| s.to_owned()),
             _extensible: (),
         })
     }
@@ -138,10 +122,8 @@ impl Encode for Peripheral {
         };
         match self.display_name {
             Some(ref v) => {
-                elem.children.push(new_element(
-                    "displayName",
-                    Some(format!("{}", v)),
-                ));
+                elem.children
+                    .push(new_element("displayName", Some(format!("{}", v))));
             }
             None => (),
         };
@@ -154,10 +136,8 @@ impl Encode for Peripheral {
         };
         match self.description {
             Some(ref v) => {
-                elem.children.push(new_element(
-                    "description",
-                    Some(format!("{}", v)),
-                ));
+                elem.children
+                    .push(new_element("description", Some(format!("{}", v))));
             }
             None => (),
         };
@@ -172,17 +152,13 @@ impl Encode for Peripheral {
             None => (),
         };
 
-        let interrupts: Result<Vec<_>, _> = self.interrupt
-            .iter()
-            .map(Interrupt::encode)
-            .collect();
+        let interrupts: Result<Vec<_>, _> = self.interrupt.iter().map(Interrupt::encode).collect();
 
         elem.children.append(&mut interrupts?);
 
         match self.registers {
             Some(ref v) => {
-                let children: Result<Vec<_>, _> =
-                    v.iter().map(|&ref e| e.encode()).collect();
+                let children: Result<Vec<_>, _> = v.iter().map(|&ref e| e.encode()).collect();
 
                 elem.children.push(Element {
                     name: String::from("registers"),

--- a/src/svd/registercluster.rs
+++ b/src/svd/registercluster.rs
@@ -32,18 +32,14 @@ impl Parse for RegisterCluster {
     type Error = SVDError;
     fn parse(tree: &Element) -> Result<RegisterCluster, SVDError> {
         if tree.name == "register" {
-            Ok(RegisterCluster::Register(Register::parse(
-                tree,
-            )?))
+            Ok(RegisterCluster::Register(Register::parse(tree)?))
         } else if tree.name == "cluster" {
             Ok(RegisterCluster::Cluster(Cluster::parse(tree)?))
         } else {
-            Err(SVDError::from(
-                SVDErrorKind::InvalidRegisterCluster(
-                    tree.clone(),
-                    tree.name.clone(),
-                ),
-            ))
+            Err(SVDError::from(SVDErrorKind::InvalidRegisterCluster(
+                tree.clone(),
+                tree.name.clone(),
+            )))
         }
     }
 }

--- a/src/svd/registerclusterarrayinfo.rs
+++ b/src/svd/registerclusterarrayinfo.rs
@@ -40,18 +40,15 @@ impl Encode for RegisterClusterArrayInfo {
     fn encode(&self) -> Result<Element, SVDError> {
         let mut e = new_element("registerClusterArrayInfo", None);
 
-        e.children.push(new_element(
-            "dim",
-            Some(format!("{}", self.dim)),
-        ));
+        e.children
+            .push(new_element("dim", Some(format!("{}", self.dim))));
         e.children.push(new_element(
             "dimIncrement",
             Some(format!("{}", self.dim_increment)),
         ));
 
         if let Some(ref di) = self.dim_index {
-            e.children
-                .push(new_element("dimIndex", Some(di.join(","))));
+            e.children.push(new_element("dimIndex", Some(di.join(","))));
         }
 
         Ok(e)

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -45,10 +45,7 @@ impl Parse for RegisterInfo {
     fn parse(tree: &Element) -> Result<RegisterInfo, SVDError> {
         let name = tree.get_child_text("name")?;
         RegisterInfo::_parse(tree, name.clone())
-            .context(SVDErrorKind::Other(format!(
-                "In register `{}`",
-                name
-            )))
+            .context(SVDErrorKind::Other(format!("In register `{}`", name)))
             .map_err(|e| e.into())
     }
 }
@@ -83,10 +80,7 @@ impl RegisterInfo {
                     None
                 }
             },
-            write_constraint: parse::optional::<WriteConstraint>(
-                "writeConstraint",
-                tree,
-            )?,
+            write_constraint: parse::optional::<WriteConstraint>("writeConstraint", tree)?,
             modified_write_values: parse::optional::<ModifiedWriteValues>(
                 "modifiedWriteValues",
                 tree,
@@ -116,30 +110,24 @@ impl Encode for RegisterInfo {
 
         match self.alternate_group {
             Some(ref v) => {
-                elem.children.push(new_element(
-                    "alternateGroup",
-                    Some(format!("{}", v)),
-                ));
+                elem.children
+                    .push(new_element("alternateGroup", Some(format!("{}", v))));
             }
             None => (),
         }
 
         match self.alternate_register {
             Some(ref v) => {
-                elem.children.push(new_element(
-                    "alternateRegister",
-                    Some(format!("{}", v)),
-                ));
+                elem.children
+                    .push(new_element("alternateRegister", Some(format!("{}", v))));
             }
             None => (),
         }
 
         match self.derived_from {
             Some(ref v) => {
-                elem.children.push(new_element(
-                    "derivedFrom",
-                    Some(format!("{}", v)),
-                ));
+                elem.children
+                    .push(new_element("derivedFrom", Some(format!("{}", v))));
             }
             None => (),
         }
@@ -161,20 +149,16 @@ impl Encode for RegisterInfo {
 
         match self.reset_value {
             Some(ref v) => {
-                elem.children.push(new_element(
-                    "resetValue",
-                    Some(format!("0x{:08.x}", v)),
-                ));
+                elem.children
+                    .push(new_element("resetValue", Some(format!("0x{:08.x}", v))));
             }
             None => (),
         };
 
         match self.reset_mask {
             Some(ref v) => {
-                elem.children.push(new_element(
-                    "resetMask",
-                    Some(format!("0x{:08.x}", v)),
-                ));
+                elem.children
+                    .push(new_element("resetMask", Some(format!("0x{:08.x}", v))));
             }
             None => (),
         };
@@ -235,9 +219,7 @@ mod tests {
                 reset_mask: Some(0x00000023),
                 fields: Some(vec![Field {
                     name: String::from("WREN"),
-                    description: Some(String::from(
-                        "Enable Write/Erase Controller",
-                    )),
+                    description: Some(String::from("Enable Write/Erase Controller")),
                     bit_range: BitRange {
                         offset: 0,
                         width: 1,

--- a/src/svd/writeconstraint.rs
+++ b/src/svd/writeconstraint.rs
@@ -36,19 +36,13 @@ impl Parse for WriteConstraint {
                 "writeAsRead" => Ok(WriteConstraint::WriteAsRead(
                     tree.get_child_bool(field.as_ref())?,
                 )),
-                "useEnumeratedValues" => {
-                    Ok(WriteConstraint::UseEnumeratedValues(
-                        tree.get_child_bool(field.as_ref())?,
-                    ))
-                }
-                "range" => Ok(WriteConstraint::Range(
-                    WriteConstraintRange::parse(tree.get_child_elem(
-                        field.as_ref(),
-                    )?)?,
+                "useEnumeratedValues" => Ok(WriteConstraint::UseEnumeratedValues(
+                    tree.get_child_bool(field.as_ref())?,
                 )),
-                _ => Err(
-                    SVDErrorKind::UnknownWriteConstraint(tree.clone()).into(),
-                ),
+                "range" => Ok(WriteConstraint::Range(WriteConstraintRange::parse(
+                    tree.get_child_elem(field.as_ref())?,
+                )?)),
+                _ => Err(SVDErrorKind::UnknownWriteConstraint(tree.clone()).into()),
             }
         } else {
             Err(SVDErrorKind::MoreThanOneWriteConstraint(tree.clone()).into())
@@ -62,9 +56,7 @@ impl Encode for WriteConstraint {
 
     fn encode(&self) -> Result<Element, SVDError> {
         let v = match *self {
-            WriteConstraint::WriteAsRead(v) => {
-                new_element("writeAsRead", Some(format!("{}", v)))
-            }
+            WriteConstraint::WriteAsRead(v) => new_element("writeAsRead", Some(format!("{}", v))),
             WriteConstraint::UseEnumeratedValues(v) => {
                 new_element("useEnumeratedValues", Some(format!("{}", v)))
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,13 +13,7 @@ use error::{SVDError, SVDErrorKind};
 
 macro_rules! try {
     ($e:expr) => {
-        $e.expect(concat!(
-            file!(),
-            ":",
-            line!(),
-            " ",
-            stringify!($e)
-        ))
+        $e.expect(concat!(file!(), ":", line!(), " ", stringify!($e)))
     };
 }
 
@@ -41,8 +35,9 @@ impl Parse for u32 {
             u32::from_str_radix(
                 &str::replace(&text.to_lowercase()["#".len()..], "x", "0"),
                 2,
-            ).context(SVDErrorKind::Other(format!("{} invalid", text)))
-                .map_err(|e| e.into())
+            )
+            .context(SVDErrorKind::Other(format!("{} invalid", text)))
+            .map_err(|e| e.into())
         } else if text.starts_with("0b") {
             // Handle strings in the binary form of:
             // 0b01101x1
@@ -71,11 +66,9 @@ impl Parse for BoolParse {
             _ => match text.parse() {
                 Ok(b) => b,
                 Err(e) => {
-                    return Err(SVDErrorKind::InvalidBooleanValue(
-                        tree.clone(),
-                        text.clone(),
-                        e,
-                    ).into())
+                    return Err(
+                        SVDErrorKind::InvalidBooleanValue(tree.clone(), text.clone(), e).into(),
+                    )
                 }
             },
         })


### PR DESCRIPTION
without this parsing the output of encode fails when there is no description
field

the first commit can be ignored as it just runs cargo-fmt