### PR TITLE
derivedFrom is an attribute, not a child of <register>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@
 
 extern crate either;
 extern crate xmltree;
-#[macro_use]
 extern crate failure;
 
 #[cfg(feature = "unproven")]

--- a/src/svd/registerinfo.rs
+++ b/src/svd/registerinfo.rs
@@ -59,7 +59,7 @@ impl RegisterInfo {
             name,
             alternate_group: tree.get_child_text_opt("alternateGroup")?,
             alternate_register: tree.get_child_text_opt("alternateRegister")?,
-            derived_from: tree.get_child_text_opt("derivedFrom")?,
+            derived_from: tree.attributes.get("derivedFrom").map(|s| s.to_owned()),
             description: tree.get_child_text("description")?,
             address_offset: tree.get_child_u32("addressOffset")?,
             size: parse::optional::<u32>("size", tree)?,
@@ -136,10 +136,8 @@ impl Encode for RegisterInfo {
 
         match self.derived_from {
             Some(ref v) => {
-                elem.children.push(new_element(
-                    "derivedFrom",
-                    Some(format!("{}", v)),
-                ));
+                elem.attributes
+                    .insert(String::from("derivedFrom"), format!("{}", v));
             }
             None => (),
         }
@@ -254,13 +252,12 @@ mod tests {
                 _extensible: (),
             },
             "
-            <register>
+            <register derivedFrom=\"derived from\">
                 <name>WRITECTRL</name>
                 <description>Write Control Register</description>
                 <addressOffset>0x8</addressOffset>
                 <alternateGroup>alternate group</alternateGroup>
                 <alternateRegister>alternate register</alternateRegister>
-                <derivedFrom>derived from</derivedFrom>
                 <size>32</size>
                 <access>read-write</access>
                 <resetValue>0x00000000</resetValue>


### PR DESCRIPTION
This got accidentally refactored to be parsed as a child,
but this is actually an attribute (consistent with peripheral.rs).

Fixup and test via `cargo test --features unproven`

See also: https://github.com/rust-embedded/svd2rust/pull/256