### PR TITLE
Show unknown access variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,8 +26,8 @@ pub enum SVDErrorKind {
     ParseError(Element),
     #[fail(display = "NameMismatch")]
     NameMismatch(Element),
-    #[fail(display = "unknown access variant found")]
-    UnknownAccessType(Element),
+    #[fail(display = "unknown access variant '{}' found", _1)]
+    UnknownAccessType(Element, String),
     #[fail(display = "Bit range invalid, {:?}", _1)]
     InvalidBitRange(Element, InvalidBitRange),
     #[fail(display = "Unknown write constraint")]

--- a/src/svd/access.rs
+++ b/src/svd/access.rs
@@ -30,7 +30,7 @@ impl Parse for Access {
             "read-writeOnce" => Ok(Access::ReadWriteOnce),
             "write-only" => Ok(Access::WriteOnly),
             "writeOnce" => Ok(Access::WriteOnce),
-            _ => Err(SVDErrorKind::UnknownAccessType(tree.clone()).into()),
+            _ => Err(SVDErrorKind::UnknownAccessType(tree.clone(), text).into()),
         }
     }
 }


### PR DESCRIPTION
The ARM Musca-B1 SVD has access "read", cf. https://github.com/rust-embedded/svd2rust/issues/376